### PR TITLE
fix access restrictions on Windows 

### DIFF
--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -19,7 +19,15 @@ module.exports = {
                 errorCallback(pickerCancelMessage);
                 return;
             }
-            successCallback(file.path);
+
+            // file must be copied to local folder to be accessible by app..
+            const localFolder = Windows.Storage.ApplicationData.current.localFolder;
+            file.copyAsync(localFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
+            .done(function (savedFile) {
+                successCallback('ms-appdata:///local/' + savedFile.name);
+            }, function(err) {
+                errorCallback(pickerErrorMessage);
+            });
         }, function () {
             errorCallback(pickerErrorMessage);
         });


### PR DESCRIPTION
Fix access restrictions on Windows by copying picked file to local app data folder.

this seems to be necessary as a) cordova-plugin-file can not work with local filesystem paths or Uris like "C:\\..." or "file:///C:/..." and b) WinRT restricts later access to picked files.

So copy the file to local app data folder directly after file is picked can be used as a workaround (the same procedure is also done f.e. by cordova-plugin-camera..).
