### PR TITLE
Added the ability to pass extraMIME in filter object 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Requires Cordova >= 2.8.0
 
 ## Install with Cordova CLI
-	$ cordova plugin add http://github.com/ihadeed/cordova-filechooser.git
+	$ cordova plugin add http://github.com/KDPInnovations/cordova-filechooser.git
 
 ## Install with Plugman
 	$ plugman --platform android --project /path/to/project \ 
-		--plugin http://github.com/ihadeed/cordova-filechooser.git
+		--plugin http://github.com/KDPInnovations/cordova-filechooser.git
 
 ## API
 
@@ -21,6 +21,8 @@ fileChooser.open(successCallback. failureCallback); // without mime filter
 
 ```javascript
 { "mime": "application/pdf" }  // text/plain, image/png, image/jpeg, audio/wav etc
+  // defaults to "*/*"
+  {"mime": "*/*", "extraMIME" : "application/pdf,image/png,image/jpeg,video/mp4,video/mpg"}
 ```
 
 The success callback gets the uri of the selected file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filechooser",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cordova FileChooser Plugin",
   "main": "index.js",
   "scripts": {
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ihadeed/cordova-filechooser.git"
+    "url": "git+https://github.com/KDPInnovations/cordova-filechooser.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ihadeed/cordova-filechooser/issues"
+    "url": "https://github.com/KDPInnovations/cordova-filechooser/issues"
   },
-  "homepage": "https://github.com/ihadeed/cordova-filechooser#readme",
+  "homepage": "https://github.com/KDPInnovations/cordova-filechooser#readme",
   "cordova": {
     "id": "cordova-plugin-filechooser",
     "platforms": [

--- a/src/android/FileChooser.java
+++ b/src/android/FileChooser.java
@@ -19,6 +19,7 @@ public class FileChooser extends CordovaPlugin {
     private static final int PICK_FILE_REQUEST = 1;
 
     public static final String MIME = "mime";
+    public static final String ExtraMIME ="extraMIME";
 
     CallbackContext callback;
 
@@ -36,11 +37,15 @@ public class FileChooser extends CordovaPlugin {
 
     public void chooseFile(JSONObject filter, CallbackContext callbackContext) {
         String uri_filter = filter.has(MIME) ? filter.optString(MIME) : "*/*";
-
+        boolean hasExtraMIME = filter.has(ExtraMIME) ? true : false;
         // type and title should be configurable
 
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType(uri_filter);
+        if (hasExtraMIME) {
+            String [] mimeTypes=filter.optString(ExtraMIME).split(",");
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+        }
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
 


### PR DESCRIPTION
Added the ability to pass extraMIME in filter object in order to use intent.putExtra(Intent.EXTRA_MIME_TYPES) in order to correctly filter files displayed in intents including Google Drive.  Pass extraMIME as a comma delimited string in filter, for example “image/jpeg, image/png, video/mpg, application/pdf”